### PR TITLE
Ndg8f/update copy fields/manu 7505

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/solr7.3.x/staging/kmassets/conf/schema.xml
+++ b/solr7.3.x/staging/kmassets/conf/schema.xml
@@ -59,8 +59,8 @@
    <field name="description" type="text_general" indexed="true" stored="true" multiValued="true"/>
    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="comments" type="text_general" indexed="true" stored="true"/>
-   <field name="author" type="text_general" indexed="true" stored="true"/>
-   <field name="creator" type="string" indexed="true" stored="true" multiValued="true"/>
+   <field name="author" type="text_general" indexed="true" stored="true"/> <!-- Not used? -->
+   <field name="creator" type="text_kw" indexed="true" stored="true" multiValued="true"/>
    <field name="keywords" type="string" indexed="true" stored="true"/>
    <field name="category" type="text_general" indexed="true" stored="true"/>
    <field name="resourcename" type="text_general" indexed="true" stored="true"/>
@@ -223,6 +223,7 @@
      <!-- Title Copy Fields -->
      <copyField source="title_*" dest="title"/>
      <copyField source="*_title_s" dest="title"/>
+     <copyField source="caption" dest="title"/>     
      
      <!-- Tibetan Title Copy Fields -->
      <copyField source="title_alt_bo" dest="title_bo"/>
@@ -232,6 +233,7 @@
      <copyField source="title_long_tibt" dest="title_bo"/>
      <copyField source="title_short_bo" dest="title_bo"/>
      <copyField source="title_short_tibt" dest="title_bo"/>
+     <copyField source="caption_bo" dest="title_bo"/>
      
      <!-- Kmap Name Copy Fields -->
      <copyField source="name_*" dest="names_ss"/>

--- a/solr7.3.x/staging/kmassets/conf/schema.xml
+++ b/solr7.3.x/staging/kmassets/conf/schema.xml
@@ -56,7 +56,7 @@
    <field name="name_autocomplete" type="text_autocomplete" multiValued="true" stored="true"/>
    <field name="title" type="text_kw" indexed="true" stored="true" multiValued="true"/>
    <field name="subject" type="text_general" indexed="true" stored="true"/>
-   <field name="description" type="text_general" indexed="true" stored="true"/>
+   <field name="description" type="text_general" indexed="true" stored="true" multiValued="true"/>
    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="comments" type="text_general" indexed="true" stored="true"/>
    <field name="author" type="text_general" indexed="true" stored="true"/>
@@ -115,38 +115,7 @@
    <!-- timestamps and versions -->
    <field name="kmaps_timestamp" type="tdate" indexed="true" stored="true" multiValued="false" />
    <field name="kmaps_version" type="long" indexed="true" stored="true" multiValued="false" />
-
-  <!-- tibetan searching OLD -->
-   <dynamicField name="*_tibt" type="text_kw" multiValued="true" indexed="true" stored="true"/>
-   <dynamicField name="*_tibt_sort" type="text_kw" multiValued="false" indexed="true" stored="true"/>
-
-  <!-- tibetan searching NEW -->
-   <dynamicField name="*_bo" type="text_bo" multiValued="true" indexed="true" stored="true"/>
-
-  <!-- sanskrit -->
-   <dynamicField name="*_sa" type="text_hi" multiValued="true" indexed="true" stored="true"/>
-
-  <!-- chinese -->
-   <dynamicField name="*_zh" type="text_cjk" multiValued="true" indexed="true" stored="true"/>
- 
-  <!-- special name encoding entries -->
-   <dynamicField name="name_*" type="text_general" multiValued="true" indexed="true" stored="true"/>
-   <field name="name_zh" type="text_cjk" multiValued="true" stored="true"/>
-
-   <!-- default typed field for latin scripts -->
-   <dynamicField name="*_latin" type="string" multiValued="true" indexed="true" stored="true"/>
-   <dynamicField name="*_latin_sort" type="string" multiValued="false" indexed="true" stored="true"/>
-
-  <!-- idfacet fields -->
-  <fieldType name="idfacet" class="solr.TextField">
-    <analyzer type="index">
-	  <tokenizer class="solr.KeywordTokenizerFactory" />
-    </analyzer>
-    <analyzer type="query">
-	  <tokenizer class="solr.KeywordTokenizerFactory" />
-    </analyzer>
-  </fieldType>
-
+     
    <!--
      Some fields such as popularity and manu_exact could be modified to
      leverage doc values:
@@ -161,13 +130,36 @@
      would also make the index faster to load, more memory-efficient and more
      NRT-friendly.
      -->
-
+     
+     <!-- **** Dynamic Fields **** -->
+     
    <!-- Dynamic field definitions allow using convention over configuration
        for fields via the specification of patterns to match field names. 
        EXAMPLE:  name="*_i" will match any field ending in _i (like myid_i, z_i)
        RESTRICTION: the glob-like pattern in the name attribute must have
        a "*" only at the start or the end.  -->
-   
+     <!-- tibetan searching OLD -->
+     <dynamicField name="*_tibt" type="text_kw" multiValued="true" indexed="true" stored="true"/>
+     <dynamicField name="*_tibt_sort" type="text_kw" multiValued="false" indexed="true" stored="true"/>
+     
+     <!-- tibetan searching NEW -->
+     <dynamicField name="*_bo" type="text_bo" multiValued="true" indexed="true" stored="true"/>
+     
+     <!-- sanskrit -->
+     <dynamicField name="*_sa" type="text_hi" multiValued="true" indexed="true" stored="true"/>
+     
+     <!-- chinese -->
+     <dynamicField name="*_zh" type="text_cjk" multiValued="true" indexed="true" stored="true"/>
+     
+     <!-- special name encoding entries -->
+     <dynamicField name="name_*" type="text_general" multiValued="true" indexed="true" stored="true"/>
+     <field name="name_zh" type="text_cjk" multiValued="true" stored="true"/>
+     
+     <!-- default typed field for latin scripts -->
+     <dynamicField name="*_latin" type="string" multiValued="true" indexed="true" stored="true"/>
+     <dynamicField name="*_latin_sort" type="string" multiValued="false" indexed="true" stored="true"/>
+     
+     <!-- SOLR default dynamic fields -->
    <dynamicField name="*_i"  type="int"    indexed="true"  stored="true"/>
    <dynamicField name="*_is" type="int"    indexed="true"  stored="true"  multiValued="true"/>
    <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" />
@@ -218,19 +210,89 @@
    <!-- idfacet field type -->
    <dynamicField name="*_idfacet" type="idfacet" multiValued="true" indexed="true" stored="true"/>
    <dynamicField name="*_rptgeom" type="location_rptgeom" indexed="true" stored="true"/>
-   <dynamicField name="*_grptgeom" type="string" indexed="true" stored="true"/><!-- KLUDGE -->
+   <dynamicField name="*_grptgeom" type="string" indexed="true" stored="true"/><!-- Geom Kludge -->
 
  <!-- Field to use to determine and enforce document uniqueness. 
       Unless this field is marked with required="false", it will be a required field
    -->
  <uniqueKey>uid</uniqueKey>
-
+     
+    <!-- **** Copy Fields **** -->
     <!-- A set of fields that are used in the general "text" search.
-         We may want to expand these in the future (ys2n) -->	
-    <copyField source="caption" dest="text"/>
-    <copyField source="summary" dest="text"/>
-    <copyField source="title" dest="text"/>
-
+         We may want to expand these in the future (ys2n) -->
+     <!-- Title Copy Fields -->
+     <copyField source="title_*" dest="title"/>
+     <copyField source="*_title_s" dest="title"/>
+     
+     <!-- Tibetan Title Copy Fields -->
+     <copyField source="title_alt_bo" dest="title_bo"/>
+     <copyField source="title_alt_tibt" dest="title_bo"/>
+     <copyField source="title_corpus_bo_t" dest="title_bo"/>
+     <copyField source="title_corpus_tibt" dest="title_bo"/>
+     <copyField source="title_long_tibt" dest="title_bo"/>
+     <copyField source="title_short_bo" dest="title_bo"/>
+     <copyField source="title_short_tibt" dest="title_bo"/>
+     
+     <!-- Kmap Name Copy Fields -->
+     <copyField source="name_*" dest="names_ss"/>
+         <!-- Chinese Name Copy Fields -->
+     <copyField source="name_pri.tib.sec.chi" dest="names_zh"/>
+     <copyField source="name_simp.chi" dest="names_zh"/>
+     <copyField source="name_trad.chi" dest="names_zh"/>
+     <copyField source="name_zh" dest="names_zh"/>
+     <copyField source="name_hans" dest="names_zh"/>
+     <copyField source="name_hant" dest="names_zh"/>
+     
+     <!-- Creator Copy Fields -->
+     <copyField source="creator_*" dest="creator"/>
+     <copyField source="contributor_*" dest="creator"/>
+     <copyField source="agent_*" dest="creator"/>
+     <copyField source="*_authors_ss" dest="creator"/>
+     <copyField source="*_authors_s" dest="creator"/>
+     <copyField source="node_user_*" dest="creator"/>
+     
+     <!-- Alt ID Copy Fields -->
+     <copyField source="uid" dest="ids_ss"/>
+     <copyField source="id" dest="ids_ss"/>
+     <copyField source="*_id_s" dest="ids_ss"/>
+     <copyField source="*_id_ss" dest="ids_ss"/>
+     
+     <!-- Description Copy Fields  -->
+     <copyField source="caption" dest="description"/>
+     <copyField source="summary" dest="description"/>
+     <copyField source="caption_*" dest="description"/>
+     <copyField source="summary_*" dest="description"/>
+        <!-- Description Copy Fields for other languages (wildcard is glob) -->
+     <copyField source="caption_*" dest="description_*"/>
+     <copyField source="summary_*" dest="description_*"/>
+     
+     <!-- Text Copy Fields -->
+     <copyField source="*_t" dest="text"/>
+     <copyField source="*_txt" dest="text"/>
+     <copyField source="*_s" dest="text"/>
+     <copyField source="*_ss" dest="text"/>
+     <copyField source="*_bo" dest="text"/>
+     <copyField source="*_zh" dest="text"/>
+     <copyField source="*_sa" dest="text"/>
+     <copyField source="name_*" dest="text"/>
+     <copyField source="agent_*" dest="text"/>
+     <copyField source="caption" dest="text"/>
+     <copyField source="summary" dest="text"/>
+     <copyField source="title" dest="text"/>
+     <copyField source="description" dest="text"/>
+     <copyField source="creator" dest="text"/>
+     
+     <!-- **** Field Types **** -->
+     <!-- idfacet fields -->
+     <fieldType name="idfacet" class="solr.TextField">
+          <analyzer type="index">
+               <tokenizer class="solr.KeywordTokenizerFactory" />
+          </analyzer>
+          <analyzer type="query">
+               <tokenizer class="solr.KeywordTokenizerFactory" />
+          </analyzer>
+     </fieldType>
+     
     <!-- The StrField type is not analyzed, but indexed/stored verbatim.
        It supports doc values but in that case the field needs to be
        single-valued and either required or have a default value.
@@ -565,14 +627,14 @@
       </analyzer>
     </fieldType>
     
-    <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
+    <fieldType name="phonetic" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.DoubleMetaphoneFilterFactory" inject="false"/>
       </analyzer>
-    </fieldtype>
+    </fieldType>
 
-    <fieldtype name="payloads" stored="false" indexed="true" class="solr.TextField" >
+    <fieldType name="payloads" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <!--
@@ -588,7 +650,7 @@
          -->
         <filter class="solr.DelimitedPayloadTokenFilterFactory" encoder="float"/>
       </analyzer>
-    </fieldtype>
+    </fieldType>
 
     <!-- lowercases the entire field value, keeping it as a single token.  -->
     <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">

--- a/solr7.3.x/staging/kmassets/conf/schema.xml
+++ b/solr7.3.x/staging/kmassets/conf/schema.xml
@@ -264,9 +264,13 @@
      <copyField source="summary" dest="description"/>
      <copyField source="caption_*" dest="description"/>
      <copyField source="summary_*" dest="description"/>
-        <!-- Description Copy Fields for other languages (wildcard is glob) -->
-     <copyField source="caption_*" dest="description_*"/>
-     <copyField source="summary_*" dest="description_*"/>
+        <!-- Description Copy Fields for other languages -->
+     <copyField source="caption_bo" dest="description_bo"/>
+     <copyField source="summary_bo" dest="description_bo"/>
+     <copyField source="caption_zh" dest="description_zh"/>
+     <copyField source="summary_zh" dest="description_zh"/>
+     <copyField source="caption_sa" dest="description_sa"/>
+     <copyField source="summary_sa" dest="description_sa"/>
      
      <!-- Text Copy Fields -->
      <copyField source="*_t" dest="text"/>


### PR DESCRIPTION
@ys2n I have added the copy fields to the schema along with comments delineating the sections of the schema and few corrections and rearrangements to make it all more readable. In terms of the copy fields, I generalized what I had in the spreadsheet using wildcards more often than specific field names. In particular, check the "text" copy fields as I basically just copied all text field, string fields, and language fields into. Is that too much? Thanks!