### PR TITLE
adding missing copy field for descriptions in bo, zh, and sa languages

### DIFF
--- a/solr7.3.x/staging/kmassets/conf/schema.xml
+++ b/solr7.3.x/staging/kmassets/conf/schema.xml
@@ -278,10 +278,13 @@
         <!-- Description Copy Fields for other languages -->
      <copyField source="caption_bo" dest="descriptions_bo"/>
      <copyField source="summary_bo" dest="descriptions_bo"/>
+     <copyField source="description_bo" dest="descriptions_bo"/>
      <copyField source="caption_zh" dest="descriptions_zh"/>
      <copyField source="summary_zh" dest="descriptions_zh"/>
+     <copyField source="description_zh" dest="descriptions_zh"/>
      <copyField source="caption_sa" dest="descriptions_sa"/>
      <copyField source="summary_sa" dest="descriptions_sa"/>
+     <copyField source="description_sa" dest="descriptions_sa"/>
      
      <!-- Text Copy Fields -->
      <copyField source="*_t" dest="text"/>


### PR DESCRIPTION
@ys2n I was reviewing the copy fields and realized I left out copy fields for, e.g., description_bo -> descriptions_bo. It's a minor change. Can you merge and update the schema in SOLR at your convenience? Not a high priority. Thanks.