### PR TITLE
adding ascii-filter-factory to queries after lowercasing

### DIFF
--- a/solr7.3.x/staging/kmassets/conf/schema.xml
+++ b/solr7.3.x/staging/kmassets/conf/schema.xml
@@ -512,8 +512,8 @@
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         -->
-        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
-        <filter class="solr.LowerCaseFilterFactory"/>
+           <filter class="solr.LowerCaseFilterFactory"/>
+           <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-Tibetan.txt"/>
@@ -521,7 +521,8 @@
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+           <filter class="solr.LowerCaseFilterFactory"/>
+           <filter class="solr.ASCIIFoldingFilterFactory" />
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
It seems we need to apply the ascii-filter factory to remove diacritics to the query as well as the indexing. 